### PR TITLE
feat: network types with optional chain and env type params

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,14 @@
+export const LINK_MESSAGE = `I hereby declare that I am the address owner.`;
+
+export enum Network {
+  Goerli = 'goerli',
+  Chiado = 'chiado',
+  Mumbai = 'mumbai',
+  Mainnet = 'mainnet',
+}
+
+export enum Chain {
+  Ethereum = 'ethereum',
+  Gnosis = 'gnosis',
+  Polygon = 'polygon',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { MoneriumClient } from './client';
 export * from './types';
+export * as constants from './constants';

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,18 +6,51 @@ export type Config = {
   environments: { production: Environment; sandbox: Environment };
 };
 
-// --- Client Variables --- //
+export type ENV = 'sandbox' | 'production';
 
-export interface BearerProfile {
-  access_token: string;
-  token_type: string;
-  expires_in: number;
-  refresh_token: string;
-  profile: string;
-  userId: string;
-}
+export type EthereumTestnet = 'goerli';
+export type GnosisTestnet = 'chiado';
+export type PolygonTestnet = 'mumbai';
 
-// --- Client Methods  --- //
+export type Chain = 'ethereum' | 'gnosis' | 'polygon';
+export type Networks =
+  | EthereumTestnet
+  | GnosisTestnet
+  | PolygonTestnet
+  | 'mainnet';
+
+// -- Commons
+export type NetworkSemiStrict<C extends Chain> = C extends 'ethereum'
+  ? EthereumTestnet | 'mainnet'
+  : C extends 'gnosis'
+  ? GnosisTestnet | 'mainnet'
+  : C extends 'polygon'
+  ? PolygonTestnet | 'mainnet'
+  : never;
+
+export type NetworkStrict<
+  C extends Chain,
+  E extends ENV,
+> = E extends 'production'
+  ? 'mainnet'
+  : E extends 'sandbox'
+  ? C extends 'ethereum'
+    ? EthereumTestnet
+    : C extends 'gnosis'
+    ? GnosisTestnet
+    : C extends 'polygon'
+    ? PolygonTestnet
+    : never
+  : never;
+
+export type Network<
+  C extends Chain = Chain,
+  E extends ENV = ENV,
+> = C extends Chain
+  ? E extends ENV
+    ? NetworkStrict<C, E> & NetworkSemiStrict<C>
+    : never
+  : never;
 
 export enum Currency {
   eur = 'eur',
@@ -40,6 +73,15 @@ export interface AuthCode {
   code_verifier: string;
   redirect_uri: string;
   scope?: string;
+}
+
+export interface BearerProfile {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token: string;
+  profile: string;
+  userId: string;
 }
 
 export interface RefreshToken {
@@ -172,20 +214,6 @@ export interface Profile {
 }
 
 // -- getBalances
-
-export enum Chain {
-  polygon = 'polygon',
-  ethereum = 'ethereum',
-  gnosis = 'gnosis',
-}
-
-export enum Network {
-  mainnet = 'mainnet',
-  chiado = 'chiado',
-  goerli = 'goerli',
-  mumbai = 'mumbai',
-}
-
 export interface Balance {
   currency: Currency;
   amount: string;

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,20 +1,16 @@
 import encodeBase64Url from 'crypto-js/enc-base64url';
 import { MoneriumClient } from '../src/index';
-import {
-  Chain,
-  Currency,
-  Network,
-  Order,
-  OrderKind,
-  PaymentStandard,
-} from '../src/types';
+import { LINK_MESSAGE, Network, Chain } from '../src/constants';
+import { Currency, Order, OrderKind, PaymentStandard } from '../src/types';
 import SHA256 from 'crypto-js/sha256';
+
+import {
+  APP_ONE_CREDENTIALS_CLIENT_ID,
+  APP_ONE_CREDENTIALS_SECRET,
+} from './constants';
 
 const clientAuthId = '654c9c30-44d3-11ed-adac-b2efc0e6677d';
 const redirectUri = 'http://localhost:5173/integration';
-const clientId = '654e15da-44d3-11ed-adac-b2efc0e6677d';
-const clientSecret =
-  '7bb679cd597b62d77836cb877c432c80dcb1fcb6d8a2b8b703967bc9d12cd991';
 
 // punkWallet: https://punkwallet.io/pk#0x3e4936f901535680c505b073a5f70094da38e2085ecf137b153d1866a7aa826b
 // const privateKey = "0x3e4936f901535680c505b073a5f70094da38e2085ecf137b153d1866a7aa826b";
@@ -31,12 +27,38 @@ test('client initialization', () => {
   expect(client).toBeInstanceOf(MoneriumClient);
 });
 
+test(`verify link message`, () => {
+  expect(LINK_MESSAGE).toBe(message);
+});
+
+test('sandbox environment', () => {
+  const client = new MoneriumClient('sandbox');
+  const defaultClient = new MoneriumClient();
+  const url = client.getAuthFlowURI({
+    client_id: '',
+  });
+  const defaultUrl = defaultClient.getAuthFlowURI({
+    client_id: '',
+  });
+  expect(defaultUrl).toContain('https://api.monerium.dev');
+  expect(url).toContain('https://api.monerium.dev');
+});
+
+test('production environment', () => {
+  const client = new MoneriumClient('production');
+
+  const url = client.getAuthFlowURI({
+    client_id: '',
+  });
+  expect(url).toContain('https://api.monerium.app');
+});
+
 test('authenticate with client credentials', async () => {
   const client = new MoneriumClient();
 
   await client.auth({
-    client_id: clientId,
-    client_secret: clientSecret,
+    client_id: APP_ONE_CREDENTIALS_CLIENT_ID,
+    client_secret: APP_ONE_CREDENTIALS_SECRET,
   });
 
   const authContext = await client.getAuthContext();
@@ -63,8 +85,8 @@ test('link address', async () => {
   const client = new MoneriumClient();
 
   await client.auth({
-    client_id: clientId,
-    client_secret: clientSecret,
+    client_id: APP_ONE_CREDENTIALS_CLIENT_ID,
+    client_secret: APP_ONE_CREDENTIALS_SECRET,
   });
 
   const authContext = await client.getAuthContext();
@@ -77,18 +99,18 @@ test('link address', async () => {
       signature: ownerSignatureHash,
       accounts: [
         {
-          network: Network.goerli,
-          chain: Chain.ethereum,
+          network: Network.Goerli,
+          chain: Chain.Ethereum,
           currency: Currency.eur,
         },
         {
-          network: Network.chiado,
-          chain: Chain.gnosis,
+          network: Network.Chiado,
+          chain: Chain.Gnosis,
           currency: Currency.eur,
         },
         {
-          network: Network.mumbai,
-          chain: Chain.polygon,
+          network: Network.Mumbai,
+          chain: Chain.Polygon,
           currency: Currency.eur,
         },
       ],
@@ -103,8 +125,8 @@ test('get profile', async () => {
   const client = new MoneriumClient();
 
   await client.auth({
-    client_id: clientId,
-    client_secret: clientSecret,
+    client_id: APP_ONE_CREDENTIALS_CLIENT_ID,
+    client_secret: APP_ONE_CREDENTIALS_SECRET,
   });
 
   const authContext = await client.getAuthContext();
@@ -117,8 +139,8 @@ test('get balances', async () => {
   const client = new MoneriumClient();
 
   await client.auth({
-    client_id: clientId,
-    client_secret: clientSecret,
+    client_id: APP_ONE_CREDENTIALS_CLIENT_ID,
+    client_secret: APP_ONE_CREDENTIALS_SECRET,
   });
 
   const balances = await client.getBalances();
@@ -139,8 +161,8 @@ test('get orders', async () => {
   const client = new MoneriumClient();
 
   await client.auth({
-    client_id: clientId,
-    client_secret: clientSecret,
+    client_id: APP_ONE_CREDENTIALS_CLIENT_ID,
+    client_secret: APP_ONE_CREDENTIALS_SECRET,
   });
 
   const orders = await client.getOrders();
@@ -159,8 +181,8 @@ test('get orders by profileId', async () => {
   const client = new MoneriumClient();
 
   await client.auth({
-    client_id: clientId,
-    client_secret: clientSecret,
+    client_id: APP_ONE_CREDENTIALS_CLIENT_ID,
+    client_secret: APP_ONE_CREDENTIALS_SECRET,
   });
 
   const orders = await client.getOrders({
@@ -176,8 +198,8 @@ test('get order', async () => {
   const client = new MoneriumClient();
 
   await client.auth({
-    client_id: clientId,
-    client_secret: clientSecret,
+    client_id: APP_ONE_CREDENTIALS_CLIENT_ID,
+    client_secret: APP_ONE_CREDENTIALS_SECRET,
   });
 
   const order = await client.getOrder('96cb9a3c-878d-11ed-ac14-4a76678fa2b6');
@@ -191,8 +213,8 @@ test('get tokens', async () => {
   const client = new MoneriumClient();
 
   await client.auth({
-    client_id: clientId,
-    client_secret: clientSecret,
+    client_id: APP_ONE_CREDENTIALS_CLIENT_ID,
+    client_secret: APP_ONE_CREDENTIALS_SECRET,
   });
 
   const tokens = await client.getTokens();
@@ -215,8 +237,8 @@ test('place order', async () => {
   const client = new MoneriumClient();
 
   await client.auth({
-    client_id: clientId,
-    client_secret: clientSecret,
+    client_id: APP_ONE_CREDENTIALS_CLIENT_ID,
+    client_secret: APP_ONE_CREDENTIALS_SECRET,
   });
   const authContext = await client.getAuthContext();
   const profile = await client.getProfile(authContext.profiles[0].id);
@@ -224,7 +246,7 @@ test('place order', async () => {
     (a) =>
       a.address === publicKey &&
       a.currency === Currency.eur &&
-      a.network === Network.goerli,
+      a.network === Network.Goerli,
   );
 
   const date = 'Thu, 29 Dec 2022 14:58 +00:00';
@@ -251,8 +273,8 @@ test('place order', async () => {
     },
     message: placeOrderMessage,
     memo: 'Powered by Monerium SDK',
-    chain: Chain.ethereum,
-    network: Network.goerli,
+    chain: Chain.Ethereum,
+    network: Network.Goerli,
   });
 
   const expected = {
@@ -287,8 +309,8 @@ test('place order', async () => {
 //   const client = new MoneriumClient();
 
 //   await client.auth({
-//     client_id: clientId,
-//     client_secret: clientSecret,
+//     client_id: APP_ONE_CREDENTIALS_CLIENT_ID,
+//     client_secret: APP_ONE_CREDENTIALS_SECRET,
 //   });
 
 //   // const document = client.uploadSupportingDocument();

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,0 +1,5 @@
+module.exports.APP_ONE_CREDENTIALS_CLIENT_ID =
+  '654e15da-44d3-11ed-adac-b2efc0e6677d';
+module.exports.APP_ONE_CREDENTIALS_SECRET =
+  '7bb679cd597b62d77836cb877c432c80dcb1fcb6d8a2b8b703967bc9d12cd991';
+module.exports.APP_ONE_OWNER_USER_ID = '05cc17db-17d0-11ed-81e7-a6f0ef57aabb';

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,0 +1,54 @@
+import { Network, NetworkStrict } from '../src/types';
+
+describe('Network type', () => {
+  test('valid networks', () => {
+    // loose networks
+    const goerli: Network = 'goerli';
+    const chiado: Network = 'chiado';
+    const mumbai: Network = 'mumbai';
+    const mainnet: Network = 'mainnet';
+
+    // semi-strict networks
+    const ethOnly: Network<'ethereum'> = 'mainnet';
+    const ethOnlyTest: Network<'ethereum'> = 'goerli';
+
+    const gnoOnly: Network<'gnosis'> = 'mainnet';
+    const gnoOnlyTest: Network<'gnosis'> = 'chiado';
+
+    const polOnly: Network<'polygon'> = 'mainnet';
+    const polOnlyTest: Network<'polygon'> = 'mumbai';
+
+    // strict networks
+    const ethMain: Network<'ethereum', 'production'> = 'mainnet';
+    const gnoMain: Network<'gnosis', 'production'> = 'mainnet';
+    const polMain: Network<'polygon', 'production'> = 'mainnet';
+
+    const ethTest: Network<'ethereum', 'sandbox'> = 'goerli';
+    const gnoTest: Network<'gnosis', 'sandbox'> = 'chiado';
+    const polTest: Network<'polygon', 'sandbox'> = 'mumbai';
+
+    expect(true).toBeTruthy(); // dummy assertion to indicate test passes
+  });
+
+  test('invalid networks', () => {
+    // @ts-expect-error unit test
+    const ethTestErr: Network<'ethereum', 'sandbox'> = 'chiado';
+    // @ts-expect-error unit test
+    const gnoTestErr: Network<'gnosis', 'sandbox'> = 'mumbai';
+    // @ts-expect-error unit test
+    const polTestErr: Network<'polygon', 'sandbox'> = 'goerli';
+    // @ts-expect-error unit test
+    const err1: NetworkStrict<'polygon'> = 'goerli';
+    // @ts-expect-error unit test
+    const err2: NetworkStrict<'ethereum'> = 'goerli';
+    // @ts-expect-error unit test
+    const err3: NetworkStrict = 'mainnet';
+    // @ts-expect-error unit test
+    const err4: NetworkStrict = 'goerli';
+
+    // the above invalid networks should fail type checking
+    // so there's no need for additional assertions here
+
+    expect(true).toBeTruthy(); // dummy assertion to indicate test passes
+  });
+});


### PR DESCRIPTION
BREAKING-CHANGE: network and chain enum are now types they are now exported under 'constants'
import * as sdk from '@monerium/sdk'; const { Network } = sdk.constants
new type take two optional params: Network<Chain,Environment>