### PR TITLE
feat: kind always redeem from place order #87

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -142,14 +142,15 @@ export class MoneriumClient {
   }
 
   placeOrder(order: NewOrder, profileId?: string): Promise<Order> {
+    const req = { ...order, kind: 'redeem' };
     if (profileId) {
       return this.#api<Order>(
         'post',
         `profiles/${profileId}/orders`,
-        JSON.stringify(order),
+        JSON.stringify(req),
       );
     } else {
-      return this.#api<Order>('post', `orders`, JSON.stringify(order));
+      return this.#api<Order>('post', `orders`, JSON.stringify(req));
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -326,7 +326,6 @@ export interface Token {
 // --placeOrder
 
 export interface NewOrder {
-  kind: OrderKind;
   amount: string;
   signature: string;
   accountId?: string;

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -255,7 +255,6 @@ test('place order', async () => {
     '0xe2baa7df880f140e37d4a0d9cb1aaa8969b40650f69dc826373efdcc0945050d45f64cf5a2c96fe6bba959abe1bee115cfa31cedc378233e051036cdebd992181c';
 
   const order = await client.placeOrder({
-    kind: OrderKind.redeem,
     amount: '1',
     signature: placeOrderSignatureHash,
     accountId: account?.id,


### PR DESCRIPTION
**Scope**:

Closes issue #87 

**Implementation**:

I removed kind from the `placeOrder` properties and forced the request to redeem the order.

How to test:

* [unit test](https://github.com/monerium/sdk/blob/1e69fd7c286dff2cfa1ca973ab49e41841f78b53/test/client.test.ts#L236) 
* Place an order without specifying the kind. Verify that the kind is `redeem` in the payload.